### PR TITLE
Update push-receiver and expose runtime errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/electron-push-receiver",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "A module to receive FCM notifications in electron",
   "main": "src/index.js",
   "repository": "https://github.com/MatthieuLemoine/electron-push-receiver",
@@ -9,7 +9,7 @@
   "types": "src/electron-push-receiver.d.ts",
   "dependencies": {
     "electron-config": "^1.0.0",
-    "@superhuman/push-receiver": "2.1.5"
+    "@superhuman/push-receiver": "2.1.6"
   },
   "devDependencies": {
     "eslint": "^4.9.0",

--- a/src/electron-push-receiver.d.ts
+++ b/src/electron-push-receiver.d.ts
@@ -1,10 +1,16 @@
+interface SetupOptions {
+    socketTimeout?: number;
+    socketKeepAliveDelay?: number;
+    onError?: (error: Error) => void;
+}
+
 interface ElectronPushReceiver {
     START_NOTIFICATION_SERVICE: string;
     NOTIFICATION_SERVICE_STARTED: string;
     NOTIFICATION_SERVICE_ERROR: string;
     NOTIFICATION_RECEIVED: string;
     TOKEN_UPDATED: string;
-    setup: (webContents: Electron.WebContents) => void;
+    setup: (webContents: Electron.WebContents, options?: SetupOptions) => void;
 }
 
 declare const electronPushReceiver: ElectronPushReceiver;

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,10 @@ module.exports = {
   setup,
 };
 
-let startNotificationPromise
-let started = false
+let startNotificationPromise;
+let started = false;
 
-function setup(webContents, { socketTimeout, socketKeepAliveDelay } = {}) {
+function setup(webContents, { socketTimeout, socketKeepAliveDelay, onError } = {}) {
   /**
    * @param {string} event
    * @param {(event: Electron.IpcMainEvent, fcmConfig: {
@@ -38,7 +38,7 @@ function setup(webContents, { socketTimeout, socketKeepAliveDelay } = {}) {
    */
   ipcMain.on(START_NOTIFICATION_SERVICE, async (_, fcmConfig) => {
     if (startNotificationPromise) {
-      await startNotificationPromise
+      await startNotificationPromise;
     }
 
     let credentials = config.get('credentials');
@@ -48,7 +48,7 @@ function setup(webContents, { socketTimeout, socketKeepAliveDelay } = {}) {
       return;
     }
 
-    startNotificationPromise = new Promise(async (resolve, reject) => {
+    startNotificationPromise = new Promise(async (resolve) => {
       try {
         // Retrieve saved persistentId : avoid receiving all already received notifications on start
         const persistentIds = config.get('persistentIds') || [];
@@ -60,11 +60,14 @@ function setup(webContents, { socketTimeout, socketKeepAliveDelay } = {}) {
           webContents.send(TOKEN_UPDATED, credentials.fcm.token);
         }
         // Listen for GCM/FCM notifications
-        await listen(
+        const client = await listen(
           Object.assign({}, credentials, { persistentIds }),
           onNotification(webContents),
           { socketTimeout, socketKeepAliveDelay },
         );
+        if (onError) {
+          client.on('error', onError);
+        }
         // Notify the renderer process that we are listening for notifications
         webContents.send(NOTIFICATION_SERVICE_STARTED, credentials.fcm.token);
         started = true;
@@ -73,10 +76,10 @@ function setup(webContents, { socketTimeout, socketKeepAliveDelay } = {}) {
         // Forward error to the renderer process
         webContents.send(NOTIFICATION_SERVICE_ERROR, e.message);
       } finally {
-        resolve()
-        startNotificationPromise = null
+        resolve();
+        startNotificationPromise = null;
       }
-    })
+    });
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,10 +89,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@superhuman/push-receiver@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@superhuman/push-receiver/-/push-receiver-2.1.5.tgz#c6a447fa00e7ec35683cc1e7cb3fcedb101e9bae"
-  integrity sha512-2HiEdtN+wXKxrJvNg3sP4Hoy2rW6dyDAbFpY7yA8tQFdWuzVuYyVghTTpRa/1RvShHlGADk85Ws8d/lLfGaapw==
+"@superhuman/push-receiver@2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@superhuman/push-receiver/-/push-receiver-2.1.6.tgz#c562d6ff8bc49dbec94ee6da7b1e0935d982716f"
+  integrity sha512-aDKuQn7ECH1SeMmKOoJGQRjDBP2cZnIx8vs+DkKdGtWl4bOiYVOYFHd5npwHS6RBCLHsrSrKiFlJQQL0j7T9nA==
   dependencies:
     "@cypress/request" "3.0.6"
     "@cypress/request-promise" "5.0.0"


### PR DESCRIPTION
## Summary

Bumps `@superhuman/electron-push-receiver` to `2.1.8` and updates its `@superhuman/push-receiver` dependency to `2.1.6`.

Also exposes push-receiver runtime errors through an optional `setup` callback so the native desktop app can listen for decrypt errors and report them with app-side metadata.

## Validation

- `./node_modules/.bin/eslint src`
- `npm pack --dry-run`
